### PR TITLE
Histogram: use uint64_t for total sum

### DIFF
--- a/Histogram.h
+++ b/Histogram.h
@@ -52,7 +52,7 @@ public:
 		return bins_.size();
 	}
 	/// Returns the sum of all bins (i.e. the number of data points added)
-	int binSum()
+	uint64_t binSum()
 	{
 		return bin_sum_;
 	}
@@ -122,7 +122,7 @@ protected:
 	/// bin size
 	double bin_size_;
 	/// sum of all bins (used for percentage mode)
-	int bin_sum_;
+	uint64_t bin_sum_;
 	QString xlabel_;
 	QString ylabel_;
 	QString label_;


### PR DESCRIPTION
This will prevent the signed integer overflow at approx. 2.1 billion data points.